### PR TITLE
Syntax correction for /etc/sysctl.conf (values should not be quoted)

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -89,7 +89,7 @@ action :write do
       # dupes always take the last called setting. Enabling multipe redefines
       # but only resolving to a single setting in the config
       # NOTE: I am assuming the collection is in order seen.
-      r[resource.name] = "'#{resource.value}'\n" if resource.action.include?(:write)
+      r[resource.name] = "#{resource.value}\n" if resource.action.include?(:write)
       resource.updated_by_last_action true # kinda a cludge, but oh well 
     end
   end


### PR DESCRIPTION
Great package, BTW. Incredibly useful in some work I'm doing on system tuning, which often involves twiddling sysctl settings. It's so risky to manually replicate everything to production systems.

I did find one pretty dangerous bug, at least on CentOS 6.3. The syntax for /etc/sysctl.conf doesn't allow quotes around values. On the other hand, dynamic /sbin/sysctl changes requires those quotes if the value contains embedded whitespace (as you know, since your comments make that clear).

Unfortunately, if those quotes find their way into /etc/sysctl.conf, there are errors on the system reboot. Best case, the setting is ignored and some default value is used. Worst case, the system is bricked.

---
## Just one example:
# Dynamic change:

/sbin/sysctl -n -e -w kernel.shmmax='23622320128'
# /etc/sysctl.conf line to save same change for reboot:

kernel.shmmax=23622320128

---
# If instead that /etc/sysctl.conf line is the following:

---

kernel.shmmax='23622320128'
# That will cause a system reboot to encounter this error:
# /sbin/sysctl -p /etc/sysctl.conf

error: "Invalid argument" setting key "kernel.shmmax"
