### PR TITLE
Update attribute_driver.rb

### DIFF
--- a/recipes/attribute_driver.rb
+++ b/recipes/attribute_driver.rb
@@ -22,7 +22,9 @@
 
 # values from attributes and roles
 node[:sysctl][:values].each_pair do |k, v|
-  sysctl k { value v }
+  sysctl k do
+    value v
+  end
 end
 
 include_recipe 'sysctl::default'


### PR DESCRIPTION
The original code provoked the following error during my chef-client run (on omnibus 10.32.2-3).

ERROR: NameError: Cannot find a resource for k on ubuntu version 12.04

My change fixes this error.
